### PR TITLE
Update dead_simp() invocation to current DeadRemoval class implementation

### DIFF
--- a/hands-on2/deadcode_removal.ipynb
+++ b/hands-on2/deadcode_removal.ipynb
@@ -64,7 +64,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dead_simp(ir_arch, ircfg)"
+    "deadrm = DeadRemoval(ir_arch)\n",
+    "deadrm(ircfg)"
    ]
   },
   {
@@ -95,7 +96,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/hands-on2/deadcode_unremoval.ipynb
+++ b/hands-on2/deadcode_unremoval.ipynb
@@ -80,7 +80,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dead_simp(ir_arch, ircfg)"
+    "deadrm = DeadRemoval(ir_arch)\n",
+    "deadrm(ircfg)"
    ]
   },
   {
@@ -135,7 +136,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/hands-on2/optimizer.ipynb
+++ b/hands-on2/optimizer.ipynb
@@ -10,7 +10,7 @@
     "from miasm.analysis.machine import Machine\n",
     "from miasm.analysis.binary import Container\n",
     "from miasm.analysis.cst_propag import propagate_cst_expr\n",
-    "from miasm.analysis.data_flow import dead_simp, merge_blocks, remove_empty_assignblks\n",
+    "from miasm.analysis.data_flow import DeadRemoval, merge_blocks, remove_empty_assignblks\n",
     "from future.utils import viewitems"
    ]
   },
@@ -54,17 +54,18 @@
     "entry_points = set([mdis.loc_db.get_offset_location(addr)])\n",
     "init_infos = ir_arch.arch.regs.regs_init\n",
     "cst_propag_link = propagate_cst_expr(ir_arch, ircfg, addr, init_infos)\n",
+    "deadrm = DeadRemoval(ir_arch)\n",
     "\n",
     "modified = True\n",
     "while modified:\n",
     "    modified = False\n",
-    "    modified |= dead_simp(ir_arch, ircfg)\n",
+    "    modified |= deadrm(ircfg)\n",
     "    modified |= remove_empty_assignblks(ircfg)\n",
     "\n",
     "print('After Simplification:')\n",
     "\n",
     "for lbl, irb in viewitems(ircfg.blocks):\n",
-    "    print(irb)\n"
+    "    print(irb)"
    ]
   }
  ],
@@ -84,7 +85,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/hands-on2/solved/deadcode_unremoval.ipynb
+++ b/hands-on2/solved/deadcode_unremoval.ipynb
@@ -87,7 +87,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dead_simp(ir_arch, ircfg)"
+    "deadrm = DeadRemoval(ir_arch)\n",
+    "deadrm(ircfg)"
    ]
   },
   {
@@ -142,7 +143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
dead_simp() is no longer a method available on miasm since this commit from last year:
https://github.com/cea-sec/miasm/commit/215c5ebfe9d0beed56f9391cb517ccbb7fa4f4f8#diff-2aa44a496757b4273c12695496e04735

This leads to crashing when executing hands-on2 exercises that import and/or use it (provided the environment has been installed as described with miasm built from github).

As far as I know, current implementation would be substituting `dead_simp(ir_arch, ircfg)` into

```
deadrm = DeadRemoval(ir_arch)
deadrm(ircfg)
```

I tested it myself and it seems to work well, so find in this PR the files from hands-on2 with the correction described.
